### PR TITLE
Middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,7 @@ dependencies = [
  "futures-util",
  "parking_lot 0.12.0",
  "rand",
+ "rstest",
  "serde",
  "serde_json",
  "tap",
@@ -1463,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "lapin"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe666f160ceed00abc310aa2fa58295664cf892ebffc857bbf9b754c78122ce"
+checksum = "bd03ea5831b44775e296239a64851e2fd14a80a363d202ba147009ffc994ff0f"
 dependencies = [
  "amq-protocol",
  "async-global-executor-trait",
@@ -2281,6 +2282,19 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rstest"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +446,17 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "uuid",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
 ]
 
 [[package]]
@@ -757,6 +782,12 @@ checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -1932,6 +1963,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,6 +2900,7 @@ dependencies = [
 name = "translate"
 version = "0.1.0"
 dependencies = [
+ "assert_cmd",
  "async-trait",
  "color-eyre",
  "core",
@@ -3051,6 +3116,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.4"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
+checksum = "c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
 dependencies = [
  "fnv",
  "ident_case",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
  "darling_core",
  "quote",
@@ -766,6 +766,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.10",
@@ -918,9 +919,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
 ]
@@ -968,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.8"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+checksum = "9289ed2c0440a6536e65119725cf91fc2c6b5e513bfd2e36e1134d7cca6ca12f"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1171,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1188,9 +1189,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
  "bytes",
  "fnv",
@@ -1201,7 +1202,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -1374,9 +1375,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.8.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1390,9 +1391,9 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "9e1f03d4ab4d5dc9ec2d219f86c15d2a15fc08239d1cd3b2d6a19717c0a2f443"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -1488,9 +1489,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.122"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1510,11 +1511,10 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -1699,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1902,7 +1902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.2",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -1921,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2027,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "polling"
@@ -2079,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -2177,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
 dependencies = [
  "bitflags",
 ]
@@ -2421,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.7"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "serde"
@@ -2558,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
@@ -2634,9 +2634,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2900,7 +2900,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2935,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.24"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -3397,9 +3396,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.34.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -3410,33 +3409,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.34.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.34.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.34.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "tap",
  "tempfile",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2824,6 +2830,28 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "translate"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "color-eyre",
+ "core",
+ "eyre",
+ "figment",
+ "futures-util",
+ "md5",
+ "once_cell",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.10",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a"
+checksum = "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
@@ -749,6 +749,28 @@ name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "delay"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "chrono",
+ "color-eyre",
+ "core",
+ "diesel",
+ "diesel_migrations",
+ "eyre",
+ "figment",
+ "futures-util",
+ "parking_lot 0.12.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.10",
+ "uuid",
+]
 
 [[package]]
 name = "derivative"
@@ -781,6 +803,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "diesel"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d"
+dependencies = [
+ "byteorder",
+ "chrono",
+ "diesel_derives",
+ "libsqlite3-sys",
+ "r2d2",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "diesel_migrations"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c"
+dependencies = [
+ "migrations_internals",
+ "migrations_macros",
 ]
 
 [[package]]
@@ -862,9 +918,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
 ]
@@ -912,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9289ed2c0440a6536e65119725cf91fc2c6b5e513bfd2e36e1134d7cca6ca12f"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1115,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1132,9 +1188,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "h2"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -1145,7 +1201,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -1318,9 +1374,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1334,9 +1390,9 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inout"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1f03d4ab4d5dc9ec2d219f86c15d2a15fc08239d1cd3b2d6a19717c0a2f443"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -1432,9 +1488,19 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1444,10 +1510,11 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -1510,6 +1577,27 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "migrations_internals"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4fc84e4af020b837029e017966f86a1c2d5e83e64b589963d5047525995860"
+dependencies = [
+ "diesel",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mime"
@@ -1611,9 +1699,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1814,7 +1902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -1833,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1939,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polling"
@@ -1991,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
@@ -2024,6 +2112,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot 0.11.2",
+ "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -2078,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -2273,6 +2372,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,9 +2421,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 
 [[package]]
 name = "serde"
@@ -2450,9 +2558,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
@@ -2526,9 +2634,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2792,6 +2900,7 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2826,9 +2935,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -3288,9 +3397,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -3301,33 +3410,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a"
+checksum = "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
@@ -764,6 +764,7 @@ dependencies = [
  "figment",
  "futures-util",
  "parking_lot 0.12.0",
+ "rand",
  "serde",
  "serde_json",
  "tempfile",
@@ -919,9 +920,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
 ]
@@ -969,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9289ed2c0440a6536e65119725cf91fc2c6b5e513bfd2e36e1134d7cca6ca12f"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1172,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1189,9 +1190,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "h2"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -1202,7 +1203,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -1375,9 +1376,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1391,9 +1392,9 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inout"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1f03d4ab4d5dc9ec2d219f86c15d2a15fc08239d1cd3b2d6a19717c0a2f443"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -1452,9 +1453,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1489,9 +1490,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1511,10 +1512,11 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -1699,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1902,7 +1904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -1921,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2027,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "polling"
@@ -2079,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
@@ -2177,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -2421,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 
 [[package]]
 name = "serde"
@@ -2480,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
+checksum = "946fa04a8ac43ff78a1f4b811990afb9ddbdf5890b46d6dda0ba1998230138b7"
 dependencies = [
  "rustversion",
  "serde",
@@ -2491,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
+checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2558,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
@@ -2634,9 +2636,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2900,6 +2902,7 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2934,9 +2937,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -3264,9 +3267,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3274,9 +3277,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3289,9 +3292,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3301,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3311,9 +3314,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3324,15 +3327,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3350,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
 ]
@@ -3396,9 +3399,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -3409,33 +3412,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["auth", "coordinator", "core", "workers/twitter", "workers/bililive"]
+members = ["auth", "coordinator", "core", "middlewares/translate", "workers/bililive", "workers/twitter"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["auth", "coordinator", "core", "middlewares/translate", "workers/bililive", "workers/twitter"]
+members = ["auth", "coordinator", "core", "middlewares/delay", "middlewares/translate", "workers/bililive", "workers/twitter"]

--- a/bacon.toml
+++ b/bacon.toml
@@ -18,6 +18,7 @@ ctrl-d = "scroll-page(1)"
 
 [jobs.clippy]
 command = ["cargo", "clippy", "--workspace", "--tests", "--color", "always", "--", "-W", "clippy::all", "-W", "clippy::nursery", "-W", "clippy::pedantic"]
+watch = ["src", "tests"]
 need_stdout = false
 
 [jobs.test]

--- a/middlewares/delay/.gitignore
+++ b/middlewares/delay/.gitignore
@@ -1,0 +1,2 @@
+db.sqlite
+.env

--- a/middlewares/delay/Cargo.toml
+++ b/middlewares/delay/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "delay"
+version = "0.1.0"
+edition = "2021"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono = "0.4"
+color-eyre = "0.6"
+diesel = { version = "1.4", features = ["chrono", "sqlite", "r2d2"] }
+eyre = "0.6"
+figment = { version = "0.10", features = ["env"] }
+futures-util = { version = "0.3" }
+parking_lot = "0.12"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sg-core = { package = "core", path = "../../core", features = ["mq"] }
+tokio = { version = "1.17", features = ["rt", "rt-multi-thread", "parking_lot", "time", "net", "macros"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+diesel_migrations = "1.4"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+uuid = "0.8"
+figment = { version = "0.10", features = ["env", "test"] }

--- a/middlewares/delay/Cargo.toml
+++ b/middlewares/delay/Cargo.toml
@@ -13,10 +13,10 @@ eyre = "0.6"
 figment = { version = "0.10", features = ["env"] }
 futures-util = { version = "0.3" }
 parking_lot = "0.12"
-tap = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sg-core = { package = "core", path = "../../core", features = ["mq"] }
+tap = "1.0"
 tokio = { version = "1.17", features = ["rt", "rt-multi-thread", "parking_lot", "time", "net", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -24,7 +24,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 assert_cmd = "2.0"
 figment = { version = "0.10", features = ["env", "test"] }
-sg-core = { package = "core", path = "../../core", features = ["mq", "mock"] }
 rand = "0.8"
+rstest = "0.12"
+sg-core = { package = "core", path = "../../core", features = ["mq", "mock"] }
 tempfile = "3.3"
 uuid = "0.8"

--- a/middlewares/delay/Cargo.toml
+++ b/middlewares/delay/Cargo.toml
@@ -23,5 +23,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 assert_cmd = "2.0"
 figment = { version = "0.10", features = ["env", "test"] }
+rand = "0.8"
 tempfile = "3.3"
 uuid = "0.8"

--- a/middlewares/delay/Cargo.toml
+++ b/middlewares/delay/Cargo.toml
@@ -13,6 +13,7 @@ eyre = "0.6"
 figment = { version = "0.10", features = ["env"] }
 futures-util = { version = "0.3" }
 parking_lot = "0.12"
+tap = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sg-core = { package = "core", path = "../../core", features = ["mq"] }

--- a/middlewares/delay/Cargo.toml
+++ b/middlewares/delay/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 assert_cmd = "2.0"
 figment = { version = "0.10", features = ["env", "test"] }
+sg-core = { package = "core", path = "../../core", features = ["mq", "mock"] }
 rand = "0.8"
 tempfile = "3.3"
 uuid = "0.8"

--- a/middlewares/delay/Cargo.toml
+++ b/middlewares/delay/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 chrono = "0.4"
 color-eyre = "0.6"
 diesel = { version = "1.4", features = ["chrono", "sqlite", "r2d2"] }
+diesel_migrations = "1.4"
 eyre = "0.6"
 figment = { version = "0.10", features = ["env"] }
 futures-util = { version = "0.3" }
@@ -18,9 +19,9 @@ sg-core = { package = "core", path = "../../core", features = ["mq"] }
 tokio = { version = "1.17", features = ["rt", "rt-multi-thread", "parking_lot", "time", "net", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-diesel_migrations = "1.4"
 
 [dev-dependencies]
 assert_cmd = "2.0"
-uuid = "0.8"
 figment = { version = "0.10", features = ["env", "test"] }
+tempfile = "3.3"
+uuid = "0.8"

--- a/middlewares/delay/diesel.toml
+++ b/middlewares/delay/diesel.toml
@@ -1,0 +1,5 @@
+# For documentation on how to configure this file,
+# see diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"

--- a/middlewares/delay/migrations/2022-04-04-102209_delayed_messages/down.sql
+++ b/middlewares/delay/migrations/2022-04-04-102209_delayed_messages/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE delayed_messages;

--- a/middlewares/delay/migrations/2022-04-04-102209_delayed_messages/up.sql
+++ b/middlewares/delay/migrations/2022-04-04-102209_delayed_messages/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+CREATE TABLE delayed_messages
+(
+    id          BIGINT PRIMARY KEY NOT NULL ON CONFLICT REPLACE,
+    middlewares TEXT               NOT NULL,
+    body        TEXT               NOT NULL,
+    created_at  TIMESTAMP          NOT NULL,
+    deliver_at  TIMESTAMP          NOT NULL
+)

--- a/middlewares/delay/src/config.rs
+++ b/middlewares/delay/src/config.rs
@@ -1,0 +1,75 @@
+//! Translate middleware config.
+
+use eyre::Result;
+use figment::providers::{Env, Serialized};
+use figment::Figment;
+use serde::{Deserialize, Serialize};
+
+/// Coordinator config.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Config {
+    /// AMQP connection url.
+    pub amqp_url: String,
+    /// AMQP exchange name.
+    pub amqp_exchange: String,
+    /// Database connection url.
+    pub database_url: String,
+}
+
+impl Config {
+    /// Load config from environment variables.
+    ///
+    /// # Errors
+    /// Returns error if part of the config is invalid.
+    pub fn from_env() -> Result<Self> {
+        Ok(Figment::from(Serialized::defaults(Self::default()))
+            .merge(Env::prefixed("MIDDLEWARE_"))
+            .extract()?)
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            amqp_url: String::from("amqp://guest:guest@localhost:5672"),
+            amqp_exchange: String::from("stargazer-reborn"),
+            database_url: "db.sqlite".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use figment::Jail;
+
+    use crate::config::Config;
+
+    #[test]
+    fn must_default() {
+        Jail::expect_with(|_| {
+            assert_eq!(Config::from_env().unwrap(), Config::default());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn must_from_env() {
+        Jail::expect_with(|jail| {
+            jail.set_env("MIDDLEWARE_AMQP_URL", "amqp://admin:admin@localhost:5672");
+            jail.set_env("MIDDLEWARE_AMQP_EXCHANGE", "some_exchange");
+            jail.set_env(
+                "MIDDLEWARE_DATABASE_URL",
+                "mysql://guest:guest@localhost/test",
+            );
+            assert_eq!(
+                Config::from_env().unwrap(),
+                Config {
+                    amqp_url: String::from("amqp://admin:admin@localhost:5672"),
+                    amqp_exchange: String::from("some_exchange"),
+                    database_url: String::from("mysql://guest:guest@localhost/test"),
+                }
+            );
+            Ok(())
+        });
+    }
+}

--- a/middlewares/delay/src/db.rs
+++ b/middlewares/delay/src/db.rs
@@ -1,0 +1,81 @@
+use std::fmt::Debug;
+use std::io::Write;
+
+use chrono::NaiveDateTime;
+use diesel::backend::Backend;
+use diesel::deserialize::FromSql;
+use diesel::serialize::{Output, ToSql};
+use diesel::sql_types;
+use diesel::{AsExpression, FromSqlRow, Insertable, Queryable};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use sg_core::models::Event;
+use sg_core::mq::Middlewares;
+
+use crate::schema::delayed_messages;
+
+#[derive(Debug, Clone, Queryable, Insertable)]
+#[table_name = "delayed_messages"]
+pub struct DelayedMessage {
+    pub id: i64,
+    pub middlewares: MiddlewaresWrapper,
+    pub body: Json<Event>,
+    pub created_at: NaiveDateTime,
+    pub deliver_at: NaiveDateTime,
+}
+
+#[derive(FromSqlRow, AsExpression, Serialize, Deserialize, Debug, Clone)]
+#[serde(transparent)]
+#[sql_type = "sql_types::Text"]
+pub struct Json<T: Sized>(pub T);
+
+impl<T, DB> FromSql<sql_types::Text, DB> for Json<T>
+where
+    T: DeserializeOwned,
+    DB: Backend,
+    String: FromSql<sql_types::Text, DB>,
+{
+    fn from_sql(bytes: Option<&DB::RawValue>) -> diesel::deserialize::Result<Self> {
+        let s = String::from_sql(bytes)?;
+        Ok(Self(serde_json::from_str(&s)?))
+    }
+}
+
+impl<T, DB> ToSql<sql_types::Text, DB> for Json<T>
+where
+    T: Serialize + Debug,
+    DB: Backend,
+    String: ToSql<sql_types::Text, DB>,
+{
+    fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> diesel::serialize::Result {
+        let s = serde_json::to_string(&self.0)?;
+        s.to_sql(out)
+    }
+}
+
+#[derive(FromSqlRow, AsExpression, Debug, Clone)]
+#[sql_type = "sql_types::Text"]
+pub struct MiddlewaresWrapper(pub Middlewares);
+
+impl<DB> FromSql<sql_types::Text, DB> for MiddlewaresWrapper
+where
+    DB: Backend,
+    String: FromSql<sql_types::Text, DB>,
+{
+    fn from_sql(bytes: Option<&DB::RawValue>) -> diesel::deserialize::Result<Self> {
+        let s = String::from_sql(bytes)?;
+        Ok(Self(s.parse().unwrap()))
+    }
+}
+
+impl<DB> ToSql<sql_types::Text, DB> for MiddlewaresWrapper
+where
+    DB: Backend,
+    String: ToSql<sql_types::Text, DB>,
+{
+    fn to_sql<W: Write>(&self, out: &mut Output<W, DB>) -> diesel::serialize::Result {
+        let s = self.0.to_string();
+        s.to_sql(out)
+    }
+}

--- a/middlewares/delay/src/db.rs
+++ b/middlewares/delay/src/db.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::io::Write;
 
-use chrono::NaiveDateTime;
+use chrono::{NaiveDateTime, Utc};
 use diesel::backend::Backend;
 use diesel::deserialize::FromSql;
 use diesel::serialize::{Output, ToSql};
@@ -23,6 +23,18 @@ pub struct DelayedMessage {
     pub body: Json<Event>,
     pub created_at: NaiveDateTime,
     pub deliver_at: NaiveDateTime,
+}
+
+impl DelayedMessage {
+    pub fn new(id: i64, middlewares: Middlewares, body: Event, deliver_at: NaiveDateTime) -> Self {
+        Self {
+            id,
+            middlewares: MiddlewaresWrapper(middlewares),
+            body: Json(body),
+            created_at: Utc::now().naive_utc(),
+            deliver_at,
+        }
+    }
 }
 
 #[derive(FromSqlRow, AsExpression, Serialize, Deserialize, Debug, Clone)]

--- a/middlewares/delay/src/main.rs
+++ b/middlewares/delay/src/main.rs
@@ -1,0 +1,78 @@
+#[macro_use]
+extern crate diesel;
+#[macro_use]
+extern crate diesel_migrations;
+
+use std::sync::Arc;
+
+use chrono::{NaiveDateTime, Utc};
+use diesel::r2d2::{ConnectionManager, Pool};
+use diesel::SqliteConnection;
+use eyre::Context;
+use eyre::Result;
+use futures_util::StreamExt;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+use sg_core::mq::{MessageQueue, RabbitMQ};
+
+use crate::config::Config;
+use crate::db::{DelayedMessage, Json, MiddlewaresWrapper};
+use crate::scheduler::Scheduler;
+use crate::schema::delayed_messages::dsl::delayed_messages;
+
+mod config;
+mod db;
+mod scheduler;
+mod schema;
+
+embed_migrations!();
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let config = Config::from_env().wrap_err("Failed to load config from environment variables")?;
+
+    let pool = Pool::new(ConnectionManager::<SqliteConnection>::new(
+        &config.database_url,
+    ))
+    .wrap_err("Failed to connect to SQLite database")?;
+
+    embedded_migrations::run(&pool.get()?).wrap_err("Failed to run migration script")?;
+
+    let mq = RabbitMQ::new(&config.amqp_url, &config.amqp_exchange)
+        .await
+        .wrap_err("Failed to connect to AMQP")?;
+    let mut consumer = mq.consume(Some("delay")).await;
+
+    let scheduler = Arc::new(Scheduler::new(pool, mq));
+    scheduler.cleanup();
+    scheduler.load();
+
+    while let Some(Ok((next, mut event))) = consumer.next().await {
+        info!(event_id = %event.id, ?next, "Received event");
+
+        if let (Some(id), Some(deliver_at)) = (
+            event.fields.remove("x-delay-id").and_then(|v| v.as_i64()),
+            event
+                .fields
+                .remove("x-delay-at")
+                .and_then(|v| v.as_i64())
+                .map(|i| NaiveDateTime::from_timestamp(i, 0)),
+        ) {
+            let delayed_message = DelayedMessage {
+                id,
+                middlewares: MiddlewaresWrapper(next),
+                body: Json(event),
+                created_at: Utc::now().naive_utc(),
+                deliver_at,
+            };
+            scheduler.add_task(delayed_message, true);
+        }
+    }
+    Ok(())
+}

--- a/middlewares/delay/src/main.rs
+++ b/middlewares/delay/src/main.rs
@@ -8,13 +8,15 @@ use std::sync::Arc;
 use chrono::NaiveDateTime;
 use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::SqliteConnection;
-use eyre::Context;
 use eyre::Result;
+use eyre::{Context, ContextCompat};
 use futures_util::StreamExt;
-use tracing::info;
+use tap::Pipe;
+use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
 
-use sg_core::mq::{MessageQueue, RabbitMQ};
+use sg_core::models::Event;
+use sg_core::mq::{MessageQueue, Middlewares, RabbitMQ};
 
 use crate::config::Config;
 use crate::db::DelayedMessage;
@@ -53,20 +55,49 @@ async fn main() -> Result<()> {
     scheduler.cleanup();
     scheduler.load();
 
-    while let Some(Ok((next, mut event))) = consumer.next().await {
-        info!(event_id = %event.id, ?next, "Received event");
+    while let Some(Ok((next, event))) = consumer.next().await {
+        let event_id = event.id;
+        info!(%event_id, ?next, "Received event");
 
-        if let (Some(id), Some(deliver_at)) = (
-            event.fields.remove("x-delay-id").and_then(|v| v.as_i64()),
-            event
-                .fields
-                .remove("x-delay-at")
-                .and_then(|v| v.as_i64())
-                .map(|i| NaiveDateTime::from_timestamp(i, 0)),
-        ) {
-            let delayed_message = DelayedMessage::new(id, next, event, deliver_at);
-            scheduler.add_task(delayed_message, true);
+        if let Err(error) = handle_event(next, event, &scheduler) {
+            error!(%event_id, ?error, "Failed to process event");
         }
     }
+    Ok(())
+}
+
+fn handle_event(next: Middlewares, mut event: Event, scheduler: &Arc<Scheduler>) -> Result<()> {
+    let id = event
+        .fields
+        .remove("x-delay-id")
+        .wrap_err("Missing `x-delay-at`")?
+        .as_i64()
+        .wrap_err("Not a integer: `x-delay-at`")?;
+
+    let cancel = if let Some(cancel) = event.fields.remove("x-delay-cancel") {
+        // If `x-delay-cancel` is set to true, we cancel the task
+        cancel
+            .as_bool()
+            .wrap_err("Not a boolean: `x-delay-cancel`")?
+    } else {
+        // There's no `x-delay-cancel` field, so this is a new delayed message
+        false
+    };
+
+    if cancel {
+        scheduler.remove_task(id);
+    } else {
+        let deliver_at = event
+            .fields
+            .remove("x-delay-at")
+            .wrap_err("Missing `x-delay-at`")?
+            .as_i64()
+            .wrap_err("Not a timestamp: `x-delay-at`")?
+            .pipe(|ts| NaiveDateTime::from_timestamp(ts, 0));
+
+        let msg = DelayedMessage::new(id, next, event, deliver_at);
+        scheduler.add_task(msg, true);
+    }
+
     Ok(())
 }

--- a/middlewares/delay/src/scheduler.rs
+++ b/middlewares/delay/src/scheduler.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Weak};
+
+use chrono::Utc;
+use diesel::associations::HasTable;
+use diesel::dsl::now;
+use diesel::r2d2::{ConnectionManager, Pool};
+use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, SqliteConnection};
+use parking_lot::Mutex;
+use tokio::time::sleep;
+use tracing::{error, info};
+
+use sg_core::mq::MessageQueue;
+use sg_core::utils::ScopedJoinHandle;
+
+use crate::schema::delayed_messages::{deliver_at, id};
+use crate::{delayed_messages, DelayedMessage};
+
+pub struct Scheduler {
+    pool: Pool<ConnectionManager<SqliteConnection>>,
+    mq: Arc<dyn MessageQueue>,
+    delayed_messages: Mutex<HashMap<i64, DelayedTask>>,
+}
+
+pub struct DelayedTask {
+    _handler: ScopedJoinHandle<()>,
+}
+
+impl DelayedTask {
+    fn new(
+        scheduler: Weak<Scheduler>,
+        mq: impl MessageQueue + 'static,
+        message: DelayedMessage,
+    ) -> Self {
+        let task = tokio::spawn(async move {
+            let delay = message.deliver_at - Utc::now().naive_utc();
+            let x_delay_id = message.id;
+            let event_id = message.body.0.id;
+            match delay.to_std() {
+                Ok(delay) => {
+                    sleep(delay).await;
+                    if let Err(error) = mq.publish(message.body.0, message.middlewares.0).await {
+                        error!(%event_id, %x_delay_id, ?error, "Unable to deliver delayed message");
+                    }
+                }
+                Err(error) => {
+                    error!(%event_id, %x_delay_id, ?error, "Deliver time is in the past");
+                }
+            }
+            if let Some(scheduler) = scheduler.upgrade() {
+                scheduler.remove_task(message.id);
+            }
+        });
+        Self {
+            _handler: ScopedJoinHandle(task),
+        }
+    }
+}
+
+impl Scheduler {
+    pub fn new(
+        pool: Pool<ConnectionManager<SqliteConnection>>,
+        mq: impl MessageQueue + 'static,
+    ) -> Self {
+        Self {
+            pool,
+            mq: Arc::new(mq),
+            delayed_messages: Mutex::new(HashMap::new()),
+        }
+    }
+    #[allow(clippy::cognitive_complexity)]
+    pub fn add_task(self: &Arc<Self>, msg: DelayedMessage, persist: bool) {
+        if persist {
+            let conn = self.pool.get().unwrap();
+            let r = diesel::insert_into(delayed_messages::table())
+                .values(&msg)
+                .execute(&conn);
+            match r {
+                Ok(count) if count == 0 => {
+                    error!(
+                        error = "No rows inserted",
+                        "Unable to persist delayed message."
+                    );
+                }
+                Err(error) => {
+                    error!(?error, "Unable to persist delayed message.");
+                }
+                _ => (),
+            }
+        }
+
+        let msg_id = msg.id;
+        let task = DelayedTask::new(Arc::downgrade(self), self.mq.clone(), msg);
+        if self.delayed_messages.lock().insert(msg_id, task).is_some() {
+            info!(id = %msg_id, "Overwriting existing delayed message");
+        } else {
+            info!(id = %msg_id, "Added delayed message");
+        }
+    }
+    pub fn remove_task(&self, task_id: i64) {
+        if self.delayed_messages.lock().remove(&task_id).is_some() {
+            let conn = self.pool.get().expect("No db conn available");
+            if let Err(error) =
+                diesel::delete(delayed_messages.filter(id.eq(task_id))).execute(&conn)
+            {
+                error!(?error, "Failed to remove task from database");
+            }
+        }
+
+        if self.delayed_messages.lock().remove(&task_id).is_some() {
+            info!(id = %task_id, "Removed delayed message");
+        } else {
+            info!(id = %task_id, "No delayed message to remove");
+        }
+    }
+    pub fn load(self: &Arc<Self>) {
+        let conn = self.pool.get().expect("No db conn available");
+        let results = delayed_messages.load::<DelayedMessage>(&conn);
+        match results {
+            Ok(messages) => {
+                for message in messages {
+                    self.add_task(message, false);
+                }
+            }
+            Err(error) => {
+                error!(?error, "Failed to load persisted delayed messages");
+            }
+        }
+    }
+    pub fn cleanup(&self) {
+        let conn = self.pool.get().expect("No db conn available");
+        let r = diesel::delete(delayed_messages::table())
+            .filter(deliver_at.lt(now))
+            .execute(&conn);
+        match r {
+            Ok(count) => {
+                info!(count = %count, "Removed misfired delayed messages from database");
+            }
+            Err(error) => {
+                error!(%error, "Failed to remove misfired delayed messages from database");
+            }
+        }
+    }
+}

--- a/middlewares/delay/src/schema.rs
+++ b/middlewares/delay/src/schema.rs
@@ -1,0 +1,9 @@
+table! {
+    delayed_messages (id) {
+        id -> BigInt,
+        middlewares -> Text,
+        body -> Text,
+        created_at -> Timestamp,
+        deliver_at -> Timestamp,
+    }
+}

--- a/middlewares/delay/tests/integration.rs
+++ b/middlewares/delay/tests/integration.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -80,10 +79,9 @@ async fn must_delay_and_send() {
 async fn must_delay_and_send_across_restart() {
     let exchange_name = format!("test_{}", rand::random::<usize>());
 
-    // Prepare temp dir.
-    let temp_dir = tempfile::tempdir().unwrap();
-    let db_path = temp_dir.path().join("test.db");
-    drop(fs::remove_file(&db_path));
+    // Prepare temp file.
+    let temp_file = tempfile::NamedTempFile::new().unwrap();
+    let db_path = temp_file.path();
 
     // Initialize messages to send and expect.
     let delay_at = SystemTime::now() + Duration::from_secs(7);
@@ -120,7 +118,7 @@ async fn must_delay_and_send_across_restart() {
         .unwrap()
         .env("MIDDLEWARE_AMQP_URL", "amqp://guest:guest@localhost:5672")
         .env("MIDDLEWARE_AMQP_EXCHANGE", &exchange_name)
-        .env("MIDDLEWARE_DATABASE_URL", &db_path)
+        .env("MIDDLEWARE_DATABASE_URL", db_path)
         .env("RUST_LOG", "info")
         .spawn()
         .unwrap();
@@ -139,7 +137,7 @@ async fn must_delay_and_send_across_restart() {
         .unwrap()
         .env("MIDDLEWARE_AMQP_URL", "amqp://guest:guest@localhost:5672")
         .env("MIDDLEWARE_AMQP_EXCHANGE", &exchange_name)
-        .env("MIDDLEWARE_DATABASE_URL", &db_path)
+        .env("MIDDLEWARE_DATABASE_URL", db_path)
         .spawn()
         .unwrap();
 

--- a/middlewares/delay/tests/integration.rs
+++ b/middlewares/delay/tests/integration.rs
@@ -1,0 +1,86 @@
+use std::process::Command;
+use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use assert_cmd::cargo::CommandCargoExt;
+use futures_util::StreamExt;
+use serde_json::json;
+use tokio::time::{sleep, timeout};
+use tracing::level_filters::LevelFilter;
+use uuid::Uuid;
+
+use sg_core::models::Event;
+use sg_core::mq::{MessageQueue, Middlewares, RabbitMQ};
+
+#[tokio::test]
+async fn must_delay_and_send() {
+    tracing_subscriber::fmt()
+        .with_max_level(LevelFilter::DEBUG)
+        .init();
+
+    let delay_at = SystemTime::now() + Duration::from_secs(5);
+    let ts = delay_at.duration_since(UNIX_EPOCH).unwrap().as_secs();
+
+    let original = Event {
+        id: Uuid::nil().into(),
+        kind: "".to_string(),
+        entity: Uuid::nil().into(),
+        fields: json!({
+            "a": "b",
+            "x-delay-id": 114_514,
+            "x-delay-at": ts
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    };
+    let expected = Event {
+        id: Uuid::nil().into(),
+        kind: "".to_string(),
+        entity: Uuid::nil().into(),
+        fields: json!({
+            "a": "b",
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    };
+
+    let mut cmd = Command::cargo_bin("delay").unwrap();
+    let mut program = cmd
+        .env("MIDDLEWARE_AMQP_URL", "amqp://guest:guest@localhost:5672")
+        .env("MIDDLEWARE_AMQP_EXCHANGE", "test")
+        .env("MIDDLEWARE_DATABASE_URL", ":memory:")
+        .spawn()
+        .unwrap();
+
+    let mq = RabbitMQ::new("amqp://guest:guest@localhost:5672", "test")
+        .await
+        .unwrap();
+    let mut consumer = mq.consume(Some("delay_debug")).await;
+
+    sleep(Duration::from_secs(1)).await;
+
+    mq.publish(
+        original,
+        Middlewares::from_str("delay_debug.delay").unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let msg = consumer.next().await.unwrap().unwrap();
+    let received_time = SystemTime::now();
+    assert_eq!(msg, (Middlewares::default(), expected));
+    let delta = match received_time.duration_since(delay_at) {
+        Ok(delta) => delta,
+        Err(e) => e.duration(),
+    };
+    assert!(dbg!(delta) < Duration::from_millis(1500));
+
+    // There's only one message.
+    assert!(timeout(Duration::from_millis(500), consumer.next())
+        .await
+        .is_err());
+
+    program.kill().unwrap();
+}

--- a/middlewares/translate/Cargo.toml
+++ b/middlewares/translate/Cargo.toml
@@ -23,4 +23,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = "0.8"
 
 [dev-dependencies]
+assert_cmd = "2.0"
 figment = { version = "0.10", features = ["env", "test"] }

--- a/middlewares/translate/Cargo.toml
+++ b/middlewares/translate/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "translate"
+version = "0.1.0"
+edition = "2021"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1"
+color-eyre = "0.6"
+eyre = "0.6"
+figment = { version = "0.10", features = ["env"] }
+futures-util = { version = "0.3" }
+md5 = "0.7"
+once_cell = "1.10"
+rand = "0.8"
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sg-core = { package = "core", path = "../../core", features = ["mq"] }
+tokio = { version = "1.17", features = ["rt", "rt-multi-thread", "parking_lot", "time", "net", "macros"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = "0.8"
+
+[dev-dependencies]
+figment = { version = "0.10", features = ["env", "test"] }

--- a/middlewares/translate/src/config.rs
+++ b/middlewares/translate/src/config.rs
@@ -16,6 +16,8 @@ pub struct Config {
     pub baidu_app_id: usize,
     /// Baidu translate app secret.
     pub baidu_app_secret: String,
+    /// Debug only.
+    pub debug: bool,
 }
 
 impl Config {
@@ -37,6 +39,7 @@ impl Default for Config {
             amqp_exchange: String::from("stargazer-reborn"),
             baidu_app_id: 0,
             baidu_app_secret: String::new(),
+            debug: false,
         }
     }
 }
@@ -62,6 +65,7 @@ mod tests {
             jail.set_env("MIDDLEWARE_AMQP_EXCHANGE", "some_exchange");
             jail.set_env("MIDDLEWARE_BAIDU_APP_ID", "1");
             jail.set_env("MIDDLEWARE_BAIDU_APP_SECRET", "<secret>");
+            jail.set_env("MIDDLEWARE_DEBUG", "true");
             assert_eq!(
                 Config::from_env().unwrap(),
                 Config {
@@ -69,6 +73,7 @@ mod tests {
                     amqp_exchange: String::from("some_exchange"),
                     baidu_app_id: 1,
                     baidu_app_secret: String::from("<secret>"),
+                    debug: true,
                 }
             );
             Ok(())

--- a/middlewares/translate/src/config.rs
+++ b/middlewares/translate/src/config.rs
@@ -1,0 +1,77 @@
+//! Translate middleware config.
+
+use eyre::Result;
+use figment::providers::{Env, Serialized};
+use figment::Figment;
+use serde::{Deserialize, Serialize};
+
+/// Middleware config.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Config {
+    /// AMQP connection url.
+    pub amqp_url: String,
+    /// AMQP exchange name.
+    pub amqp_exchange: String,
+    /// Baidu translate app id.
+    pub baidu_app_id: usize,
+    /// Baidu translate app secret.
+    pub baidu_app_secret: String,
+}
+
+impl Config {
+    /// Load config from environment variables.
+    ///
+    /// # Errors
+    /// Returns error if part of the config is invalid.
+    pub fn from_env() -> Result<Self> {
+        Ok(Figment::from(Serialized::defaults(Self::default()))
+            .merge(Env::prefixed("MIDDLEWARE_"))
+            .extract()?)
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            amqp_url: String::from("amqp://guest:guest@localhost:5672"),
+            amqp_exchange: String::from("stargazer-reborn"),
+            baidu_app_id: 0,
+            baidu_app_secret: String::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use figment::Jail;
+
+    use crate::config::Config;
+
+    #[test]
+    fn must_default() {
+        Jail::expect_with(|_| {
+            assert_eq!(Config::from_env().unwrap(), Config::default());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn must_from_env() {
+        Jail::expect_with(|jail| {
+            jail.set_env("MIDDLEWARE_AMQP_URL", "amqp://admin:admin@localhost:5672");
+            jail.set_env("MIDDLEWARE_AMQP_EXCHANGE", "some_exchange");
+            jail.set_env("MIDDLEWARE_BAIDU_APP_ID", "1");
+            jail.set_env("MIDDLEWARE_BAIDU_APP_SECRET", "<secret>");
+            assert_eq!(
+                Config::from_env().unwrap(),
+                Config {
+                    amqp_url: String::from("amqp://admin:admin@localhost:5672"),
+                    amqp_exchange: String::from("some_exchange"),
+                    baidu_app_id: 1,
+                    baidu_app_secret: String::from("<secret>"),
+                }
+            );
+            Ok(())
+        });
+    }
+}

--- a/middlewares/translate/src/main.rs
+++ b/middlewares/translate/src/main.rs
@@ -1,0 +1,46 @@
+use eyre::{Result, WrapErr};
+use futures_util::StreamExt;
+use tracing::{error, info};
+use tracing_subscriber::EnvFilter;
+
+use sg_core::mq::{MessageQueue, RabbitMQ};
+
+use crate::config::Config;
+use crate::translate::{BaiduTranslator, Translator};
+
+mod config;
+mod translate;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+
+    let config = Config::from_env().wrap_err("Failed to load config from environment variables")?;
+
+    let translator = BaiduTranslator::new(config.baidu_app_id, config.baidu_app_secret);
+
+    let mq = RabbitMQ::new(&config.amqp_url, &config.amqp_exchange)
+        .await
+        .wrap_err("Failed to connect to AMQP")?;
+
+    let mut consumer = mq.consume(Some("translate")).await;
+
+    while let Some(Ok((next, event))) = consumer.next().await {
+        info!(event_id = %event.id, ?next, "Received event");
+        let event = match translator.translate_event(event.clone()).await {
+            Ok(translated) => translated,
+            Err(e) => {
+                error!(?e, "Failed to translate event, ignore");
+                event
+            }
+        };
+        if let Err(error) = mq.publish(event, next).await {
+            error!(?error, "Failed to publish translated event");
+        }
+    }
+
+    Ok(())
+}

--- a/middlewares/translate/src/translate.rs
+++ b/middlewares/translate/src/translate.rs
@@ -1,0 +1,163 @@
+use async_trait::async_trait;
+use eyre::{ContextCompat, Result};
+use reqwest::Client;
+use serde_json::Value;
+use tracing::warn;
+
+use sg_core::models::Event;
+
+#[async_trait]
+pub trait Translator {
+    async fn translate_event(&self, mut event: Event) -> Result<Event> {
+        let translate_fields: Vec<_> = event
+            .fields
+            .remove("x-translate-fields")
+            .wrap_err("Missing `x-translate-fields`")?
+            .as_array()
+            .wrap_err("Not an array")?
+            .iter()
+            .map(|v| Ok(v.as_str().wrap_err("Not a string")?.to_string()))
+            .collect::<Result<_>>()?;
+
+        let mut fields = Value::Object(event.fields);
+        for field in translate_fields {
+            if let Some(Value::String(src)) = fields.pointer_mut(&field) {
+                match self.translate_text(src).await {
+                    Ok(t) => {
+                        *src = t;
+                    }
+                    Err(error) => {
+                        warn!(?error, %src, "Failed to translate text");
+                    }
+                }
+            } else {
+                warn!(?fields, %field, "Field not found in event");
+            }
+        }
+
+        event.fields = match fields {
+            Value::Object(o) => o,
+            _ => unreachable!(),
+        };
+        Ok(event)
+    }
+    async fn translate_text(&self, text: &str) -> Result<String>;
+}
+
+pub struct BaiduTranslator {
+    client: Client,
+    app_id: usize,
+    app_secret: String,
+}
+
+impl BaiduTranslator {
+    pub fn new(app_id: usize, app_secret: String) -> Self {
+        Self {
+            client: Client::new(),
+            app_id,
+            app_secret,
+        }
+    }
+}
+
+#[async_trait]
+impl Translator for BaiduTranslator {
+    async fn translate_text(&self, text: &str) -> Result<String> {
+        let salt: usize = rand::random();
+        let pre_sign = format!("{}{}{}{}", self.app_id, text, salt, self.app_secret);
+        let sign = format!("{:x}", md5::compute(pre_sign));
+        let resp: Value = self
+            .client
+            .get("https://fanyi-api.baidu.com/api/trans/vip/translate")
+            .query(&[("q", text), ("from", "auto"), ("to", "zh")])
+            .query(&[("appid", self.app_id)])
+            .query(&[("salt", salt)])
+            .query(&[("sign", sign)])
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(resp
+            .pointer("/trans_result/0/dst")
+            .wrap_err("invalid response")?
+            .as_str()
+            .wrap_err("not a string")?
+            .to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use eyre::Result;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use sg_core::models::Event;
+
+    use crate::translate::{BaiduTranslator, Translator};
+
+    struct MockTranslator;
+
+    #[async_trait]
+    impl Translator for MockTranslator {
+        async fn translate_text(&self, text: &str) -> Result<String> {
+            Ok(format!("test{}", text))
+        }
+    }
+
+    #[tokio::test]
+    async fn must_translate_fields() {
+        let e = Event {
+            id: Uuid::nil().into(),
+            kind: "".to_string(),
+            entity: Uuid::nil().into(),
+            fields: json!({
+                "a": "a",
+                "b": ["b1", "b2"],
+                "c": {
+                    "cc": "d"
+                },
+                "x-translate-fields": ["/a", "/b/0", "/c/cc"]
+            })
+            .as_object()
+            .unwrap()
+            .clone(),
+        };
+        let translator = MockTranslator;
+        let translated = translator.translate_event(e).await.unwrap();
+        assert_eq!(
+            translated,
+            Event {
+                id: Uuid::nil().into(),
+                kind: "".to_string(),
+                entity: Uuid::nil().into(),
+                fields: json!({
+                    "a": "testa",
+                    "b": ["testb1", "b2"],
+                    "c": {
+                        "cc": "testd"
+                    }
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_baidu_translate() {
+        if let (Some(app_id), Some(app_secret)) = (
+            option_env!("TEST_BAIDU_APP_ID"),
+            option_env!("TEST_BAIDU_APP_SECRET"),
+        ) {
+            let translator = BaiduTranslator::new(app_id.parse().unwrap(), app_secret.to_string());
+            let translated = translator
+                .translate_text("Apples are good for our health.")
+                .await
+                .unwrap();
+            assert!(!translated.is_empty());
+        }
+    }
+}

--- a/middlewares/translate/src/translate.rs
+++ b/middlewares/translate/src/translate.rs
@@ -73,6 +73,7 @@ impl Translator for BaiduTranslator {
             .query(&[("appid", self.app_id)])
             .query(&[("salt", salt)])
             .query(&[("sign", sign)])
+            .query(&[("action", 1)])
             .send()
             .await?
             .json()
@@ -156,6 +157,21 @@ mod tests {
                 .await
                 .unwrap();
             assert!(!translated.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_baidu_translate_custom_dict() {
+        if let (Some(app_id), Some(app_secret)) = (
+            option_env!("TEST_BAIDU_APP_ID"),
+            option_env!("TEST_BAIDU_APP_SECRET"),
+        ) {
+            let translator = BaiduTranslator::new(app_id.parse().unwrap(), app_secret.to_string());
+            let translated = translator
+                .translate_text("Hoshimachi Suisei is a Japanese virtual YouTuber. She began posting videos as an independent creator in March 2018.")
+                .await
+                .unwrap();
+            assert!(translated.contains("星街彗星"));
         }
     }
 }

--- a/middlewares/translate/tests/integration.rs
+++ b/middlewares/translate/tests/integration.rs
@@ -1,0 +1,84 @@
+use std::process::Command;
+use std::str::FromStr;
+use std::time::Duration;
+
+use assert_cmd::cargo::CommandCargoExt;
+use futures_util::StreamExt;
+use serde_json::json;
+use tokio::time::{sleep, timeout};
+use tracing::level_filters::LevelFilter;
+use uuid::Uuid;
+
+use sg_core::models::Event;
+use sg_core::mq::{MessageQueue, Middlewares, RabbitMQ};
+
+#[tokio::test]
+async fn must_translate_and_put_back() {
+    tracing_subscriber::fmt()
+        .with_max_level(LevelFilter::DEBUG)
+        .init();
+
+    let original = Event {
+        id: Uuid::nil().into(),
+        kind: "".to_string(),
+        entity: Uuid::nil().into(),
+        fields: json!({
+            "a": "a",
+            "b": ["b1", "b2"],
+            "c": {
+                "cc": "d"
+            },
+            "x-translate-fields": ["/a", "/b/0", "/c/cc"]
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    };
+    let translated = Event {
+        id: Uuid::nil().into(),
+        kind: "".to_string(),
+        entity: Uuid::nil().into(),
+        fields: json!({
+            "a": "testa",
+            "b": ["testb1", "b2"],
+            "c": {
+                "cc": "testd"
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    };
+
+    let mut cmd = Command::cargo_bin("translate").unwrap();
+    let mut program = cmd
+        .env("MIDDLEWARE_AMQP_URL", "amqp://guest:guest@localhost:5672")
+        .env("MIDDLEWARE_AMQP_EXCHANGE", "test")
+        .env("MIDDLEWARE_DEBUG", "true")
+        .spawn()
+        .unwrap();
+
+    let mq = RabbitMQ::new("amqp://guest:guest@localhost:5672", "test")
+        .await
+        .unwrap();
+    let mut consumer = mq.consume(Some("translate_debug")).await;
+
+    sleep(Duration::from_secs(1)).await;
+
+    mq.publish(
+        original,
+        Middlewares::from_str("translate_debug.translate").unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let msg = consumer.next().await.unwrap().unwrap();
+    assert_eq!(msg, (Middlewares::default(), translated));
+
+    // There's only one message.
+    assert!(timeout(Duration::from_millis(500), consumer.next())
+        .await
+        .is_err());
+
+    program.kill().unwrap();
+}

--- a/workers/twitter/src/twitter.rs
+++ b/workers/twitter/src/twitter.rs
@@ -25,6 +25,9 @@ pub struct Tweet {
     pub link: String,
     /// Whether the tweet is a retweet.
     pub is_rt: bool,
+    /// Fields to be translated.
+    #[serde(rename = "x-translate-fields")]
+    pub x_translate_fields: Vec<String>,
 }
 
 impl From<RawTweet> for Tweet {
@@ -48,6 +51,7 @@ impl From<RawTweet> for Tweet {
                 tweet.id
             ),
             is_rt: tweet.retweeted_status.is_some(),
+            x_translate_fields: vec!["/text".into()],
         }
     }
 }


### PR DESCRIPTION
Closes #39.

# Core

- [x] Change exchange type from fanout to topc
- [x] Helper for consuming events

# Translate

Translate specific fields of an event.

## Routing key

`#.translate`

## Attributes

`x-translate-fields`(required) - fields to translate, in json pointer format. (e.g., `/body`)

- [x] Translate through Baidu translate API
- [x] Unit tests
- [x] Integration tests

# Delay

Deliver an event later.

## Routing key

`#.delay`

## Attributes

`x-delay-id`(required) - id of the delay request. Don't to be confused with event id. Can be used to cancel this delivery. Multiple deliveries with the same delay request id will cause previous events to be discarded.
`x-delay-cancel` - if set to true, cancel the delivery with given id.
`x-delay-at`(required if `x-delay-cancel` is not set to true) - deliver the message at given timestamp. Invalid timestamps (e.g., earlier than now) will be ignored and won't overwrite an existing event.

- [x] Add new delayed message
- [x] Cancel a delivery
- [x] Unit tests
- [x] Integration tests