### PR TITLE
Several refactors and fixes in core 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,11 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    services:
+      rmq:
+        image: rabbitmq:3-alpine
+        ports:
+          - 5672:5672
     steps:
       - uses: actions/checkout@v2
         name: Checkout 🛎️

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,7 @@ dependencies = [
  "mongodb",
  "serde",
  "serde_json",
+ "tap",
  "tarpc",
  "thiserror",
  "tokio",
@@ -2820,6 +2821,22 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "translate"
+version = "0.1.0"
+dependencies = [
+ "color-eyre",
+ "core",
+ "eyre",
+ "figment",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2824,22 +2824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "translate"
-version = "0.1.0"
-dependencies = [
- "color-eyre",
- "core",
- "eyre",
- "figment",
- "futures-util",
- "reqwest",
- "serde",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.9",
-]
-
-[[package]]
 name = "trust-dns-proto"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,7 @@ dependencies = [
 name = "core"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "eyre",
  "futures-util",
  "isolanguage-1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "eyre",
  "futures-util",
  "isolanguage-1",
+ "itertools",
  "lapin",
  "mongodb",
  "serde",
@@ -818,6 +819,12 @@ dependencies = [
  "tokio",
  "url",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
@@ -1335,6 +1342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6e3a0c6f27d49cc1e869532ddeb0cfe4f9c0c076f0c5abc109e830ebe7a96a8"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,7 @@ dependencies = [
  "tokio",
  "tokio-executor-trait",
  "tokio-reactor-trait",
+ "tokio-stream",
  "tokio-tungstenite",
  "tracing",
  "url",
@@ -2680,6 +2681,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]

--- a/coordinator/src/worker.rs
+++ b/coordinator/src/worker.rs
@@ -187,7 +187,7 @@ impl WorkerGroupImpl {
                 if task.worker == Some(id) {
                     task.worker = None;
                 }
-            })
+            });
         } else {
             // Add the worker to the ring.
             self.ring.insert(id);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,7 @@ mq = ["lapin", "tokio-reactor-trait", "tokio-executor-trait"]
 eyre = "0.6"
 futures-util = { version = "0.3", features = ["sink"] }
 isolanguage-1 = { version = "0.2", features = ["serde"] }
+itertools = "0.10"
 lapin = { version = "2.0", optional = true }
 mongodb = { version = "2.2.0-beta", features = ["bson-uuid-0_8"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,4 +29,5 @@ url = { version = "2.2.2", features = ["serde"] }
 uuid = "0.8"
 
 [dev-dependencies]
-tokio = { version = "1.17", features = ["rt", "time", "net"] }
+tokio = { version = "1.17", features = ["rt", "time", "net", "sync"] }
+tokio-stream = { version = "0.1", features = ["sync"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 mq = ["lapin", "tokio-reactor-trait", "tokio-executor-trait"]
 
 [dependencies]
+async-trait = "0.1"
 eyre = "0.6"
 futures-util = { version = "0.3", features = ["sink"] }
 isolanguage-1 = { version = "0.2", features = ["serde"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ lapin = { version = "2.0", optional = true }
 mongodb = { version = "2.2.0-beta", features = ["bson-uuid-0_8"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tap = "1.0"
 tarpc = { version = "0.27", features = ["serde1", "tokio1"] }
 thiserror = "1.0"
 tokio = { version = "1.17", features = ["rt"] }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,3 +9,5 @@ pub mod models;
 pub mod mq;
 pub mod protocol;
 pub mod utils;
+
+pub use async_trait;

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -126,8 +126,6 @@ pub struct User {
     pub name: String,
     /// Avatar of the user.
     pub avatar: Url,
-    /// Admin privilege of the user, this can be set via admin web ui.
-    pub is_admin: bool,
     /// The events that the user is subscribed to.
     pub event_filter: EventFilter,
 }

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -2,7 +2,7 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::{Deref, DerefMut};
 
-use eyre::{eyre, Result, WrapErr};
+use eyre::{bail, Result, WrapErr};
 use isolanguage_1::LanguageCode;
 use mongodb::bson::oid::ObjectId;
 use mongodb::bson::Uuid;
@@ -85,15 +85,19 @@ impl Event {
         entity: impl Into<Uuid>,
         fields: impl Serialize,
     ) -> Result<Self> {
+        let value = serde_json::to_value(fields)
+            .wrap_err("event fields can't be converted into json value")?;
+        let fields = match value {
+            Value::Null => Map::new(),
+            Value::Object(m) => m,
+            _ => bail!("event field is not a map"),
+        };
+
         Ok(Self {
             id: id.into(),
             kind: kind.to_string(),
             entity: entity.into(),
-            fields: serde_json::to_value(fields)
-                .wrap_err("event fields can't be converted into json value")?
-                .as_object()
-                .ok_or_else(|| eyre!("event field is not a map"))?
-                .clone(),
+            fields,
         })
     }
     /// Create a new event with its fields set by a serializable object.

--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -75,21 +75,37 @@ pub struct Event {
 }
 
 impl Event {
-    /// Create a new event with its fields set by a serializable object.
+    /// Create a new event with a given id with its fields set by a serializable object.
     ///
     /// # Errors
     /// Returns an error if the fields cannot be serialized into a map.
-    pub fn from_serializable(kind: &str, entity: Uuid, fields: impl Serialize) -> Result<Self> {
+    pub fn from_serializable_with_id(
+        id: impl Into<Uuid>,
+        kind: &str,
+        entity: impl Into<Uuid>,
+        fields: impl Serialize,
+    ) -> Result<Self> {
         Ok(Self {
-            id: Uuid::new(),
+            id: id.into(),
             kind: kind.to_string(),
-            entity,
+            entity: entity.into(),
             fields: serde_json::to_value(fields)
                 .wrap_err("event fields can't be converted into json value")?
                 .as_object()
                 .ok_or_else(|| eyre!("event field is not a map"))?
                 .clone(),
         })
+    }
+    /// Create a new event with its fields set by a serializable object.
+    ///
+    /// # Errors
+    /// Returns an error if the fields cannot be serialized into a map.
+    pub fn from_serializable(
+        kind: &str,
+        entity: impl Into<Uuid>,
+        fields: impl Serialize,
+    ) -> Result<Self> {
+        Self::from_serializable_with_id(Uuid::new(), kind, entity, fields)
     }
 }
 

--- a/core/src/mq.rs
+++ b/core/src/mq.rs
@@ -239,7 +239,12 @@ pub mod tests {
     #[async_trait]
     impl MessageQueue for MockMQ {
         async fn publish(&self, event: Event, middlewares: Middlewares) -> Result<()> {
-            self.tx.send((format!("events.{}", middlewares), event))?;
+            let key = if middlewares.middlewares.is_empty() {
+                "events".to_string()
+            } else {
+                format!("events.{}", middlewares)
+            };
+            self.tx.send((key, event))?;
             Ok(())
         }
 

--- a/core/src/mq.rs
+++ b/core/src/mq.rs
@@ -2,9 +2,12 @@
 
 use std::convert::Infallible;
 use std::fmt::{Display, Formatter};
+use std::ops::Deref;
+use std::pin::Pin;
 use std::str::FromStr;
 use std::{iter, vec};
 
+use async_trait::async_trait;
 use eyre::Result;
 use futures_util::{future, stream, Stream, StreamExt};
 use itertools::Itertools;
@@ -19,12 +22,44 @@ use tracing::{debug, error, info};
 
 use crate::models::Event;
 
-/// A connection to a `RabbitMQ` server.
-pub struct MessageQueue {
+/// Interface of a message queue.
+#[async_trait]
+pub trait MessageQueue: Send + Sync {
+    /// Publish a tweet to the message queue.
+    ///
+    /// # Errors
+    /// Returns an error if the message can't be published.
+    async fn publish(&self, event: Event, middlewares: Middlewares) -> Result<()>;
+    /// Consume messages from the message queue.
+    ///
+    /// # Errors
+    /// Returns an error if the message can't be consumed.
+    async fn consume(
+        &self,
+        middleware: Option<&str>,
+    ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>>>>;
+}
+
+#[async_trait]
+impl<T: Deref<Target = dyn MessageQueue> + Send + Sync> MessageQueue for T {
+    async fn publish(&self, event: Event, middlewares: Middlewares) -> Result<()> {
+        self.deref().publish(event, middlewares).await
+    }
+
+    async fn consume(
+        &self,
+        middleware: Option<&str>,
+    ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>>>> {
+        self.deref().consume(middleware).await
+    }
+}
+
+/// A message queue backed by `RabbitMQ`.
+pub struct RabbitMQ {
     channel: Channel,
 }
 
-impl MessageQueue {
+impl RabbitMQ {
     /// Connect to a `RabbitMQ` server.
     ///
     /// # Errors
@@ -54,28 +89,6 @@ impl MessageQueue {
             .await?;
 
         Ok(Self { channel })
-    }
-
-    /// Publish a tweet to the message queue.
-    ///
-    /// # Errors
-    /// Returns an error if the message can't be published.
-    pub async fn publish(&self, event: Event, middlewares: Middlewares) -> Result<()> {
-        info!(event_id = %event.id, event_kind = %event.kind, ?middlewares, "Publishing event");
-        drop(
-            self.channel
-                .basic_publish(
-                    "stargazer-reborn",
-                    &iter::once(String::from("event"))
-                        .chain(middlewares.into_iter())
-                        .join("."),
-                    BasicPublishOptions::default(),
-                    &*serde_json::to_vec(&event)?,
-                    BasicProperties::default(),
-                )
-                .await?,
-        );
-        Ok(())
     }
     async fn consume_connect(&self, middleware: Option<&str>) -> Result<Consumer> {
         let routing_key = middleware.map_or_else(
@@ -112,18 +125,36 @@ impl MessageQueue {
             )
             .await?)
     }
-    /// Consume messages from the message queue.
-    ///
-    /// # Errors
-    /// Returns an error if the message can't be consumed.
-    pub async fn consume(
+}
+
+#[async_trait]
+impl MessageQueue for RabbitMQ {
+    async fn publish(&self, event: Event, middlewares: Middlewares) -> Result<()> {
+        info!(event_id = %event.id, event_kind = %event.kind, ?middlewares, "Publishing event");
+        drop(
+            self.channel
+                .basic_publish(
+                    "stargazer-reborn",
+                    &iter::once(String::from("event"))
+                        .chain(middlewares.into_iter())
+                        .join("."),
+                    BasicPublishOptions::default(),
+                    &*serde_json::to_vec(&event)?,
+                    BasicProperties::default(),
+                )
+                .await?,
+        );
+        Ok(())
+    }
+
+    async fn consume(
         &self,
         middleware: Option<&str>,
-    ) -> impl Stream<Item = Result<(Middlewares, Event)>> + Unpin {
+    ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>>>> {
         let consumer = self.consume_connect(middleware).await;
         info!(middleware = ?middleware, "Listening for events.");
         match consumer {
-            Ok(consumer) => future::Either::Left(consumer.map(|msg| match msg {
+            Ok(consumer) => Box::pin(consumer.map(|msg| match msg {
                 Ok(msg) => Ok((
                     Middlewares::from_routing_key(msg.routing_key.as_str()),
                     serde_json::from_slice(&msg.data).tap_err(|e| {
@@ -135,7 +166,7 @@ impl MessageQueue {
                     Err(e.into())
                 }
             })),
-            Err(e) => future::Either::Right(stream::once(future::ready(Err(e)))),
+            Err(e) => Box::pin(stream::once(future::ready(Err(e)))),
         }
     }
 }

--- a/core/src/mq.rs
+++ b/core/src/mq.rs
@@ -1,13 +1,23 @@
 //! Message queue for workers.
 
-use std::iter;
+use std::{iter, vec};
+
+use std::convert::Infallible;
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 use eyre::Result;
+use futures_util::{future, stream, Stream, StreamExt};
 use itertools::Itertools;
-use lapin::options::{BasicPublishOptions, ExchangeDeclareOptions};
+use lapin::{BasicProperties, Channel, Connection, ConnectionProperties, Consumer, ExchangeKind};
+use lapin::options::{
+    BasicConsumeOptions, BasicPublishOptions, ExchangeDeclareOptions, QueueBindOptions,
+    QueueDeclareOptions,
+};
 use lapin::types::FieldTable;
-use lapin::{BasicProperties, Channel, Connection, ConnectionProperties, ExchangeKind};
-use tracing::{debug, info};
+
+use tap::TapFallible;
+use tracing::{debug, error, info};
 
 use crate::models::Event;
 
@@ -28,9 +38,9 @@ impl MessageQueue {
                 .with_executor(tokio_executor_trait::Tokio::current())
                 .with_reactor(tokio_reactor_trait::Tokio),
         )
-        .await?
-        .create_channel()
-        .await?;
+            .await?
+            .create_channel()
+            .await?;
 
         debug!("Declaring exchange");
         channel
@@ -52,13 +62,13 @@ impl MessageQueue {
     ///
     /// # Errors
     /// Returns an error if the message can't be published.
-    pub async fn publish(&self, event: Event, middlewares: &[&str]) -> Result<()> {
+    pub async fn publish(&self, event: Event, middlewares: Middlewares) -> Result<()> {
         info!(event_id = %event.id, event_kind = %event.kind, "Publishing event");
         drop(
             self.channel
                 .basic_publish(
                     "stargazer-reborn",
-                    &iter::once(&"event").chain(middlewares).join("."),
+                    &iter::once(String::from("event")).chain(middlewares.into_iter()).join("."),
                     BasicPublishOptions::default(),
                     &*serde_json::to_vec(&event)?,
                     BasicProperties::default(),
@@ -66,5 +76,106 @@ impl MessageQueue {
                 .await?,
         );
         Ok(())
+    }
+    async fn consume_connect(&self, middleware: Option<&str>) -> Result<Consumer> {
+        let routing_key = middleware.map_or_else(
+            || String::from("event"),
+            |middleware| format!("#.{}", middleware),
+        );
+        let queue = self
+            .channel
+            .queue_declare(
+                "",
+                QueueDeclareOptions {
+                    exclusive: true,
+                    ..Default::default()
+                },
+                FieldTable::default(),
+            )
+            .await?;
+        self.channel
+            .queue_bind(
+                queue.name().as_str(),
+                "stargazer-reborn",
+                &routing_key,
+                QueueBindOptions::default(),
+                FieldTable::default(),
+            )
+            .await?;
+        Ok(self
+            .channel
+            .basic_consume(
+                queue.name().as_str(),
+                middleware.unwrap_or(""),
+                BasicConsumeOptions::default(),
+                FieldTable::default(),
+            )
+            .await?)
+    }
+    /// Consume messages from the message queue.
+    ///
+    /// # Errors
+    /// Returns an error if the message can't be consumed.
+    pub async fn consume(
+        &self,
+        middleware: Option<&str>,
+    ) -> impl Stream<Item=Result<(Middlewares, Event)>> + Unpin {
+        let consumer = self.consume_connect(middleware).await;
+        info!(middleware = ?middleware, "Listening for events.");
+        match consumer {
+            Ok(consumer) => future::Either::Left(consumer.map(|msg| match msg {
+                Ok(msg) => {
+                    Ok((
+                        Middlewares::from_routing_key(msg.routing_key.as_str()),
+                        serde_json::from_slice(&msg.data).tap_err(|e| {
+                            error!(routing_key = %msg.routing_key, error = ?e, "Failed to parse event");
+                        })?,
+                    ))
+                }
+                Err(e) => {
+                    error!(error = ?e, "Error consuming message.");
+                    Err(e.into())
+                }
+            })),
+            Err(e) => future::Either::Right(stream::once(future::ready(Err(e)))),
+        }
+    }
+}
+
+/// A set of middlewares.
+#[derive(Debug, Default)]
+pub struct Middlewares {
+    middlewares: Vec<String>,
+}
+
+impl Middlewares {
+    /// Obtain a middleware set from a routing key, removing its first and last component.
+    #[must_use] pub fn from_routing_key(s: &str) -> Self {
+        let mut middlewares: Vec<_> = s.split('.').skip(1).map(ToString::to_string).collect();
+        middlewares.pop();
+        Self { middlewares }
+    }
+}
+
+impl FromStr for Middlewares {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(Self { middlewares: s.split('.').map(ToString::to_string).collect() })
+    }
+}
+
+impl Display for Middlewares {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.middlewares.join("."))
+    }
+}
+
+impl IntoIterator for Middlewares {
+    type Item = String;
+    type IntoIter = vec::IntoIter<String>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.middlewares.into_iter()
     }
 }

--- a/core/src/mq.rs
+++ b/core/src/mq.rs
@@ -94,7 +94,7 @@ impl RabbitMQ {
             channel,
         })
     }
-    async fn consume_connect(&self, middleware: Option<&str>) -> Result<Consumer> {
+    async fn consumer_connect(&self, middleware: Option<&str>) -> Result<Consumer> {
         let routing_key = middleware.map_or_else(
             || String::from("event"),
             |middleware| format!("#.{}", middleware),
@@ -155,7 +155,7 @@ impl MessageQueue for RabbitMQ {
         &self,
         middleware: Option<&str>,
     ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>> + Send>> {
-        let consumer = self.consume_connect(middleware).await;
+        let consumer = self.consumer_connect(middleware).await;
         info!(middleware = ?middleware, "Listening for events.");
         match consumer {
             Ok(consumer) => Box::pin(consumer.map(|msg| match msg {

--- a/core/src/mq.rs
+++ b/core/src/mq.rs
@@ -172,7 +172,7 @@ impl MessageQueue for RabbitMQ {
 }
 
 /// A set of middlewares.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Middlewares {
     middlewares: Vec<String>,
 }

--- a/core/src/mq.rs
+++ b/core/src/mq.rs
@@ -37,7 +37,7 @@ pub trait MessageQueue: Send + Sync {
     async fn consume(
         &self,
         middleware: Option<&str>,
-    ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>>>>;
+    ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>> + Send>>;
 }
 
 #[async_trait]
@@ -49,7 +49,7 @@ impl<T: Deref<Target = dyn MessageQueue> + Send + Sync> MessageQueue for T {
     async fn consume(
         &self,
         middleware: Option<&str>,
-    ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>>>> {
+    ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>> + Send>> {
         self.deref().consume(middleware).await
     }
 }
@@ -150,7 +150,7 @@ impl MessageQueue for RabbitMQ {
     async fn consume(
         &self,
         middleware: Option<&str>,
-    ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>>>> {
+    ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>> + Send>> {
         let consumer = self.consume_connect(middleware).await;
         info!(middleware = ?middleware, "Listening for events.");
         match consumer {
@@ -246,7 +246,7 @@ pub mod tests {
         async fn consume(
             &self,
             middleware: Option<&str>,
-        ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>>>> {
+        ) -> Pin<Box<dyn Stream<Item = Result<(Middlewares, Event)>> + Send>> {
             let interested = middleware.map(std::string::ToString::to_string);
             Box::pin(
                 BroadcastStream::new(self.tx.subscribe())

--- a/workers/bililive/src/config.rs
+++ b/workers/bililive/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub id: Uuid,
     /// AMQP connection url.
     pub amqp_url: String,
+    /// AMQP exchange name.
+    pub amqp_exchange: String,
     /// The coordinator url to connect to.
     pub coordinator_url: String,
 }
@@ -34,6 +36,7 @@ impl Default for Config {
         Self {
             id: Uuid::nil(),
             amqp_url: String::from("amqp://guest:guest@localhost:5672"),
+            amqp_exchange: String::from("stargazer-reborn"),
             coordinator_url: String::from("ws://127.0.0.1:7000"),
         }
     }
@@ -60,12 +63,14 @@ mod tests {
             let id = Uuid::from_u128(1);
             jail.set_env("WORKER_ID", &id);
             jail.set_env("WORKER_AMQP_URL", "amqp://admin:admin@localhost:5672");
+            jail.set_env("WORKER_AMQP_EXCHANGE", "some_exchange");
             jail.set_env("WORKER_COORDINATOR_URL", "ws://localhost:8080");
             assert_eq!(
                 Config::from_env().unwrap(),
                 Config {
                     id,
                     amqp_url: String::from("amqp://admin:admin@localhost:5672"),
+                    amqp_exchange: String::from("some_exchange"),
                     coordinator_url: String::from("ws://localhost:8080"),
                 }
             );

--- a/workers/bililive/src/main.rs
+++ b/workers/bililive/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
 
     let config = Config::from_env().wrap_err("Failed to load config from environment variables")?;
 
-    let mq = RabbitMQ::new(&*config.amqp_url)
+    let mq = RabbitMQ::new(&config.amqp_url, &config.amqp_exchange)
         .await
         .wrap_err("Failed to connect to AMQP")?;
 

--- a/workers/bililive/src/main.rs
+++ b/workers/bililive/src/main.rs
@@ -1,15 +1,17 @@
 #![allow(clippy::module_name_repetitions)]
 
-mod bililive;
-mod config;
-mod worker;
+use eyre::{Result, WrapErr};
+use tracing_subscriber::EnvFilter;
+
+use sg_core::mq::RabbitMQ;
+use sg_core::protocol::WorkerRpcExt;
 
 use crate::config::Config;
 use crate::worker::BililiveWorker;
-use eyre::{Result, WrapErr};
-use sg_core::mq::MessageQueue;
-use sg_core::protocol::WorkerRpcExt;
-use tracing_subscriber::EnvFilter;
+
+mod bililive;
+mod config;
+mod worker;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -20,7 +22,7 @@ async fn main() -> Result<()> {
 
     let config = Config::from_env().wrap_err("Failed to load config from environment variables")?;
 
-    let mq = MessageQueue::new(&*config.amqp_url)
+    let mq = RabbitMQ::new(&*config.amqp_url)
         .await
         .wrap_err("Failed to connect to AMQP")?;
 

--- a/workers/bililive/src/worker.rs
+++ b/workers/bililive/src/worker.rs
@@ -137,7 +137,7 @@ async fn bililive_task(uid: u64, entity_id: Uuid, mq: &MessageQueue) -> Result<(
                         Ok(room) => {
                             let event =
                                 Event::from_serializable("bililive", entity_id.into(), room)?;
-                            if let Err(error) = mq.publish(event).await {
+                            if let Err(error) = mq.publish(event, &[]).await {
                                 error!(?error, "Failed to publish bililive event");
                             };
                         }

--- a/workers/bililive/src/worker.rs
+++ b/workers/bililive/src/worker.rs
@@ -135,8 +135,7 @@ async fn bililive_task(uid: u64, entity_id: Uuid, mq: impl MessageQueue) -> Resu
 
                     match LiveRoom::new(room_id).await {
                         Ok(room) => {
-                            let event =
-                                Event::from_serializable("bililive", entity_id, room)?;
+                            let event = Event::from_serializable("bililive", entity_id, room)?;
                             if let Err(error) = mq.publish(event, Middlewares::default()).await {
                                 error!(?error, "Failed to publish bililive event");
                             };

--- a/workers/bililive/src/worker.rs
+++ b/workers/bililive/src/worker.rs
@@ -136,7 +136,7 @@ async fn bililive_task(uid: u64, entity_id: Uuid, mq: impl MessageQueue) -> Resu
                     match LiveRoom::new(room_id).await {
                         Ok(room) => {
                             let event =
-                                Event::from_serializable("bililive", entity_id.into(), room)?;
+                                Event::from_serializable("bililive", entity_id, room)?;
                             if let Err(error) = mq.publish(event, Middlewares::default()).await {
                                 error!(?error, "Failed to publish bililive event");
                             };

--- a/workers/bililive/src/worker.rs
+++ b/workers/bililive/src/worker.rs
@@ -14,7 +14,7 @@ use tracing::{error, info, trace};
 use uuid::Uuid;
 
 use sg_core::models::{Event, Task};
-use sg_core::mq::MessageQueue;
+use sg_core::mq::{MessageQueue, Middlewares};
 use sg_core::protocol::WorkerRpc;
 use sg_core::utils::ScopedJoinHandle;
 
@@ -137,7 +137,7 @@ async fn bililive_task(uid: u64, entity_id: Uuid, mq: &MessageQueue) -> Result<(
                         Ok(room) => {
                             let event =
                                 Event::from_serializable("bililive", entity_id.into(), room)?;
-                            if let Err(error) = mq.publish(event, &[]).await {
+                            if let Err(error) = mq.publish(event, Middlewares::default()).await {
                                 error!(?error, "Failed to publish bililive event");
                             };
                         }

--- a/workers/bililive/src/worker.rs
+++ b/workers/bililive/src/worker.rs
@@ -22,7 +22,7 @@ use crate::bililive::LiveRoom;
 
 #[derive(Clone)]
 pub struct BililiveWorker {
-    mq: Arc<MessageQueue>,
+    mq: Arc<dyn MessageQueue>,
 
     #[allow(clippy::type_complexity)]
     tasks: Arc<Mutex<HashMap<Uuid, (Task, ScopedJoinHandle<()>)>>>,
@@ -31,7 +31,7 @@ pub struct BililiveWorker {
 impl BililiveWorker {
     /// Creates a new worker.
     #[must_use]
-    pub fn new(mq: MessageQueue) -> Self {
+    pub fn new(mq: impl MessageQueue + 'static) -> Self {
         Self {
             mq: Arc::new(mq),
             tasks: Arc::new(Mutex::new(HashMap::new())),
@@ -108,7 +108,7 @@ struct Command {
     cmd: String,
 }
 
-async fn bililive_task(uid: u64, entity_id: Uuid, mq: &MessageQueue) -> Result<()> {
+async fn bililive_task(uid: u64, entity_id: Uuid, mq: impl MessageQueue) -> Result<()> {
     let config = bililive::ConfigBuilder::new()
         .fetch_conf()
         .await

--- a/workers/twitter/src/config.rs
+++ b/workers/twitter/src/config.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub id: Uuid,
     /// AMQP connection url.
     pub amqp_url: String,
+    /// AMQP exchange name.
+    pub amqp_exchange: String,
     /// The coordinator url to connect to.
     pub coordinator_url: String,
     /// Twitter API token.
@@ -41,6 +43,7 @@ impl Default for Config {
         Self {
             id: Uuid::nil(),
             amqp_url: String::from("amqp://guest:guest@localhost:5672"),
+            amqp_exchange: String::from("stargazer-reborn"),
             coordinator_url: String::from("ws://127.0.0.1:7000"),
             twitter_token: String::new(),
             poll_interval: Duration::from_secs(60),
@@ -71,6 +74,7 @@ mod tests {
             let id = Uuid::from_u128(1);
             jail.set_env("WORKER_ID", &id);
             jail.set_env("WORKER_AMQP_URL", "amqp://admin:admin@localhost:5672");
+            jail.set_env("WORKER_AMQP_EXCHANGE", "some_exchange");
             jail.set_env("WORKER_COORDINATOR_URL", "ws://localhost:8080");
             jail.set_env("WORKER_TWITTER_TOKEN", "blabla");
             jail.set_env("WORKER_POLL_INTERVAL", "30s");
@@ -79,6 +83,7 @@ mod tests {
                 Config {
                     id,
                     amqp_url: String::from("amqp://admin:admin@localhost:5672"),
+                    amqp_exchange: String::from("some_exchange"),
                     coordinator_url: String::from("ws://localhost:8080"),
                     twitter_token: String::from("blabla"),
                     poll_interval: Duration::from_secs(30),

--- a/workers/twitter/src/main.rs
+++ b/workers/twitter/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
 
     let config = Config::from_env().wrap_err("Failed to load config from environment variables")?;
 
-    let mq = RabbitMQ::new(&*config.amqp_url)
+    let mq = RabbitMQ::new(&config.amqp_url, &config.amqp_exchange)
         .await
         .wrap_err("Failed to connect to AMQP")?;
 

--- a/workers/twitter/src/main.rs
+++ b/workers/twitter/src/main.rs
@@ -6,7 +6,7 @@
 use eyre::{Result, WrapErr};
 use tracing_subscriber::EnvFilter;
 
-use sg_core::mq::MessageQueue;
+use sg_core::mq::RabbitMQ;
 use sg_core::protocol::WorkerRpcExt;
 
 use crate::config::Config;
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
 
     let config = Config::from_env().wrap_err("Failed to load config from environment variables")?;
 
-    let mq = MessageQueue::new(&*config.amqp_url)
+    let mq = RabbitMQ::new(&*config.amqp_url)
         .await
         .wrap_err("Failed to connect to AMQP")?;
 

--- a/workers/twitter/src/worker.rs
+++ b/workers/twitter/src/worker.rs
@@ -147,7 +147,7 @@ async fn twitter_task(
             let event = Event::from_serializable("twitter", entity_id.into(), tweet)?;
 
             // Send tweet to message queue.
-            if let Err(error) = mq.publish(event).await {
+            if let Err(error) = mq.publish(event, &[]).await {
                 error!(?error, %tweet_id, "Failed to publish tweet");
             }
         }

--- a/workers/twitter/src/worker.rs
+++ b/workers/twitter/src/worker.rs
@@ -30,7 +30,7 @@ use crate::Config;
 #[derive(Clone)]
 pub struct TwitterWorker {
     token: Arc<Token>,
-    mq: Arc<MessageQueue>,
+    mq: Arc<dyn MessageQueue>,
     interval: Duration,
 
     #[allow(clippy::type_complexity)]
@@ -40,7 +40,7 @@ pub struct TwitterWorker {
 impl TwitterWorker {
     /// Creates a new worker.
     #[must_use]
-    pub fn new(config: Config, mq: MessageQueue) -> Self {
+    pub fn new(config: Config, mq: impl MessageQueue + 'static) -> Self {
         Self {
             token: Arc::new(Token::Bearer(config.twitter_token)),
             mq: Arc::new(mq),
@@ -132,7 +132,7 @@ async fn twitter_task(
     user_id: UserID,
     token: &Token,
     entity_id: Uuid,
-    mq: &MessageQueue,
+    mq: impl MessageQueue,
     poll_interval: Duration,
 ) -> Result<()> {
     let mut ticker = interval(poll_interval);

--- a/workers/twitter/src/worker.rs
+++ b/workers/twitter/src/worker.rs
@@ -19,7 +19,7 @@ use tracing::{error, info};
 use uuid::Uuid;
 
 use sg_core::models::{Event, Task};
-use sg_core::mq::MessageQueue;
+use sg_core::mq::{MessageQueue, Middlewares};
 use sg_core::protocol::WorkerRpc;
 use sg_core::utils::ScopedJoinHandle;
 
@@ -147,7 +147,7 @@ async fn twitter_task(
             let event = Event::from_serializable("twitter", entity_id.into(), tweet)?;
 
             // Send tweet to message queue.
-            if let Err(error) = mq.publish(event, &[]).await {
+            if let Err(error) = mq.publish(event, Middlewares::default()).await {
                 error!(?error, %tweet_id, "Failed to publish tweet");
             }
         }

--- a/workers/twitter/src/worker.rs
+++ b/workers/twitter/src/worker.rs
@@ -19,7 +19,7 @@ use tracing::{error, info};
 use uuid::Uuid;
 
 use sg_core::models::{Event, Task};
-use sg_core::mq::{MessageQueue, Middlewares};
+use sg_core::mq::MessageQueue;
 use sg_core::protocol::WorkerRpc;
 use sg_core::utils::ScopedJoinHandle;
 
@@ -144,10 +144,10 @@ async fn twitter_task(
         for raw_tweet in resp?.response {
             let tweet_id = raw_tweet.id;
             let tweet = Tweet::from(raw_tweet);
-            let event = Event::from_serializable("twitter", entity_id.into(), tweet)?;
+            let event = Event::from_serializable("twitter", entity_id, tweet)?;
 
             // Send tweet to message queue.
-            if let Err(error) = mq.publish(event, Middlewares::default()).await {
+            if let Err(error) = mq.publish(event, "translate".parse().unwrap()).await {
                 error!(?error, %tweet_id, "Failed to publish tweet");
             }
         }


### PR DESCRIPTION
When implementing middlewares, I've found several design flaws and bugs in core. To fix them, I must introduce some breaking changes.

# Models

1. `Event::from_serializable` now accepts unit type as `fields` input.
2. New method `Event::from_serializable_with_id` accepts `id`, `kind`, `entity` and `fields` to create an `Event`. It's merely for test code.

# MQ

1. `MessageQueue` is extracted out as a trait. The original implementation is now called `RabbitMQ`.
2. A new type `Middlewares` is added. It represents a chain of middlewares.
3. A new method `consume` is added to `MessageQueue`. It accepts an optional string to filter related events. Returns a stream of (Middlewares, Event), in which `Middlewares` is the preceding middleware chain (self excluded).
4. `RabbitMQ` implementation was once connected to exchange `events` rather than `stargazer-reborn`, and it was hard-coded. Now its constructor accepts an exchange name to connect to.
5. There's a new mock `MessageQueue` implementation for tests.
6. Tests are added against `MessageQueue`. There are currently two properties that must hold for an implementation:
    - messages must be received in the same order as they were sent
    - only messages intended for this middleware are consumed