### PR TITLE
build: use rust 1.60 stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout 🛎️
-      - run: rustup show
+      - run: rust update && rustup show
         name: Setup Cargo Toolchain 🛎️
       - uses: Swatinem/rust-cache@v1
       - uses: mbrobbel/rustfmt-check@master
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout 🛎️
-      - run: rustup show
+      - run: rust update && rustup show
         name: Setup Cargo Toolchain 🛎️
       - uses: Swatinem/rust-cache@v1
       - name: Start MongoDB
@@ -42,9 +42,7 @@ jobs:
         with:
           mongodb-replica-set: rs0
       - uses: actions-rs/cargo@v1
-        name: Prepare cargo-nextest 🛎️
-        with:
-          command: install
-          args: --locked cargo-nextest
-      - run: cargo nextest run -P ci
         name: Running Tests 🚀
+        with:
+          command: test
+          args: --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout 🛎️
-      - run: rust update && rustup show
+      - run: rustup update && rustup show
         name: Setup Cargo Toolchain 🛎️
       - uses: Swatinem/rust-cache@v1
       - uses: mbrobbel/rustfmt-check@master
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout 🛎️
-      - run: rust update && rustup show
+      - run: rustup update && rustup show
         name: Setup Cargo Toolchain 🛎️
       - uses: Swatinem/rust-cache@v1
       - name: Start MongoDB

--- a/core/src/adapter.rs
+++ b/core/src/adapter.rs
@@ -79,14 +79,14 @@ mod tests {
 
     use crate::adapter::WsTransport;
 
-    const fn assert_transport<T>()
+    fn assert_transport<T>()
     where
         T: Transport<ClientMessage<()>, Response<()>>,
     {
     }
 
     #[test]
-    const fn must_adapter_transport() {
+    fn must_adapter_transport() {
         assert_transport::<WsTransport<WebSocketStream<TcpStream>, _>>();
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
This PR switches the rust channel from nightly to stable. Also, fix some minor issues which is not stabilized yet, particularly `const_fn_trait_bound`.