### PR TITLE
feat(core): impl `Deref` and `DerefMut` for `Middlewares`

### DIFF
--- a/bots/telegram/src/bot.rs
+++ b/bots/telegram/src/bot.rs
@@ -1,0 +1,75 @@
+use color_eyre::{eyre::ensure, Result};
+use futures::StreamExt;
+use sg_api::client::Client;
+use sg_core::mq::{MessageQueue, RabbitMQ};
+use teloxide::{
+    adaptors::{AutoSend, DefaultParseMode},
+    prelude::*,
+    types::ParseMode,
+    Bot as TeloxideBot,
+};
+use tokio::select;
+use tracing::{error, info};
+
+use crate::config::Config;
+
+type Bot = AutoSend<DefaultParseMode<TeloxideBot>>;
+
+pub struct TgBot<B> {
+    config: Config,
+    bot: B,
+    client: Client,
+}
+
+impl TgBot<Bot> {
+    pub async fn from_env() -> Result<Self> {
+        let config = Config::from_env()?;
+        let bot = TeloxideBot::new(&config.bot_token)
+            .parse_mode(ParseMode::Html)
+            .auto_send();
+        let me = bot.get_me().await?;
+        info!(username = %me.username(), "Telegram Bot API logged in");
+        let client = Client::new(config.api_url.clone())?;
+
+        Ok(Self::new(config, bot, client))
+    }
+
+    async fn start_bot(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn start_event_handler(&self) -> Result<()> {
+        let mq = RabbitMQ::new(&self.config.amqp_url, &self.config.amqp_exchange).await?;
+        let mut stream = mq.consume(None).await;
+
+        while let Some(Ok((middlewares, event))) = stream.next().await {
+            // ensure!(middlewares.is_empty(), "unexpected middlewares"); // TODO: impl Deref<[String]> for Middlewares
+        }
+
+        Ok(())
+    }
+
+    pub async fn start(self) -> Result<()> {
+        select! {
+            res = self.start_bot() => {
+                error!("Bot quit");
+                res?;
+            },
+            res = self.start_event_handler() => {
+                error!("Event handler quit");
+                res?;
+            },
+        }
+        Ok(())
+    }
+}
+
+impl<B> TgBot<B> {
+    pub fn new(config: Config, bot: B, client: Client) -> Self {
+        Self {
+            config,
+            bot,
+            client,
+        }
+    }
+}

--- a/bots/telegram/src/command.rs
+++ b/bots/telegram/src/command.rs
@@ -1,0 +1,4 @@
+use teloxide::{
+    prelude::{Requester, RequesterExt},
+    Bot,
+};

--- a/bots/telegram/src/config.rs
+++ b/bots/telegram/src/config.rs
@@ -1,0 +1,79 @@
+//! Translate middleware config.
+
+use color_eyre::Result;
+use figment::providers::{Env, Serialized};
+use figment::Figment;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// Coordinator config.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Config {
+    /// AMQP connection url.
+    pub amqp_url: String,
+    /// AMQP exchange name.
+    pub amqp_exchange: String,
+    /// Database connection url.
+    pub api_url: Url,
+    /// Telegram bot token.
+    pub bot_token: String,
+}
+
+impl Config {
+    /// Load config from environment variables.
+    ///
+    /// # Errors
+    /// Returns error if part of the config is invalid.
+    pub fn from_env() -> Result<Self> {
+        Ok(Figment::from(Serialized::defaults(Self::default()))
+            .merge(Env::prefixed("TG_"))
+            .extract()?)
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            amqp_url: String::from("amqp://guest:guest@localhost:5672"),
+            amqp_exchange: String::from("stargazer-reborn"),
+            api_url: Url::parse("http://localhost:8080").unwrap(),
+            bot_token: String::from(""),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use figment::Jail;
+    use url::Url;
+
+    use crate::config::Config;
+
+    #[test]
+    fn must_default() {
+        Jail::expect_with(|_| {
+            assert_eq!(Config::from_env().unwrap(), Config::default());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn must_from_env() {
+        Jail::expect_with(|jail| {
+            jail.set_env("TG_AMQP_URL", "amqp://admin:admin@localhost:5672");
+            jail.set_env("TG_AMQP_EXCHANGE", "some_exchange");
+            jail.set_env("TG_API_URL", "http://localhost:8080");
+            jail.set_env("TG_BOT_TOKEN", "some_token");
+            assert_eq!(
+                Config::from_env().unwrap(),
+                Config {
+                    amqp_url: String::from("amqp://admin:admin@localhost:5672"),
+                    amqp_exchange: String::from("some_exchange"),
+                    api_url: Url::parse("http://localhost:8080").unwrap(),
+                    bot_token: String::from("some_token"),
+                }
+            );
+            Ok(())
+        });
+    }
+}

--- a/core/src/mq.rs
+++ b/core/src/mq.rs
@@ -1,10 +1,10 @@
 //! Message queue for workers.
 
-use std::convert::Infallible;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::pin::Pin;
 use std::str::FromStr;
+use std::{convert::Infallible, ops::DerefMut};
 use std::{iter, vec};
 
 use async_trait::async_trait;
@@ -216,6 +216,20 @@ impl IntoIterator for Middlewares {
 
     fn into_iter(self) -> Self::IntoIter {
         self.middlewares.into_iter()
+    }
+}
+
+impl Deref for Middlewares {
+    type Target = [String];
+
+    fn deref(&self) -> &[String] {
+        &self.middlewares
+    }
+}
+
+impl DerefMut for Middlewares {
+    fn deref_mut(&mut self) -> &mut [String] {
+        &mut self.middlewares
     }
 }
 


### PR DESCRIPTION
This gives access to inner details of `Middlewares`, which is currently
only accessble with `IntoIterator`. Functions like `is_empty` will be
handy for users.
