### PR TITLE
feat(core): impl `Deref` and `DerefMut` for `Middlewares`

### DIFF
--- a/core/src/mq.rs
+++ b/core/src/mq.rs
@@ -1,10 +1,10 @@
 //! Message queue for workers.
 
+use std::convert::Infallible;
 use std::fmt::{Display, Formatter};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::str::FromStr;
-use std::{convert::Infallible, ops::DerefMut};
 use std::{iter, vec};
 
 use async_trait::async_trait;

--- a/core/src/mq.rs
+++ b/core/src/mq.rs
@@ -1,10 +1,10 @@
 //! Message queue for workers.
 
-use std::convert::Infallible;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
 use std::pin::Pin;
 use std::str::FromStr;
+use std::{convert::Infallible, ops::DerefMut};
 use std::{iter, vec};
 
 use async_trait::async_trait;
@@ -191,6 +191,19 @@ impl Middlewares {
         let mut middlewares: Vec<_> = s.split('.').skip(1).map(ToString::to_string).collect();
         middlewares.pop();
         Self { middlewares }
+    }
+}
+
+impl Deref for Middlewares {
+    type Target = [String];
+    fn deref(&self) -> &Self::Target {
+        &self.middlewares
+    }
+}
+
+impl DerefMut for Middlewares {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.middlewares
     }
 }
 


### PR DESCRIPTION
This gives access to inner details of `Middlewares`, which is currently
only accessble with `IntoIterator`. Functions like `is_empty` will be
handy for users.
