### PR TITLE
feat(core/config): support dotenv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "core_derive",
+ "dotenvy",
  "eyre",
  "figment",
  "futures-util",
@@ -1008,10 +1009,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e851a83c30366fd01d75b913588e95e74a1705c1ecc5d58b1f8e1a6d556525f"
+dependencies = [
+ "dirs",
+]
 
 [[package]]
 name = "educe"
@@ -2432,6 +2462,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2021"
 [features]
 mq = ["lapin", "tokio-reactor-trait", "tokio-executor-trait"]
 mock = ["tokio/sync", "tokio-stream/sync"]
-config = ["figment", "core_derive"]
+config = ["figment", "core_derive", "dotenvy"]
 
 [dependencies]
 async-trait = "0.1"
 core_derive = { path = "../core_derive", optional = true }
+dotenvy = { version = "0.15", optional = true }
 eyre = "0.6"
 figment = { version = "0.10", features = ["env"], optional = true }
 futures-util = { version = "0.3", features = ["sink"] }

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -154,6 +154,10 @@ mod figment_ext {
         T: Deserialize<'a> + ConfigDefault,
     {
         fn from_env(prefix: &str) -> Result<Self> {
+            #[cfg(feature = "dotenvy")]
+            if let Ok(path) = dotenvy::dotenv() {
+                tracing::info!("Loading config from .env file: {}", path.display());
+            }
             Ok(Figment::from(Serialized::defaults(Self::config_defaults()))
                 .merge(Env::prefixed(prefix).split("__"))
                 .extract()?)


### PR DESCRIPTION
I believe it's handy to support loading env vars from dotenv file when testing.