### PR TITLE
fix(core/config): inherit is ignored when explicit default is present

### DIFF
--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -431,6 +431,26 @@ mod tests {
 
     #[derive(Deserialize, Config)]
     #[config(core = "crate")]
+    struct ConfigWithInheritAndExplicitDefaultsTwo {
+        #[config(inherit, default = r#"{ "c": 42 }"#)]
+        a: Nested,
+    }
+
+    #[test]
+    fn must_config_with_inherit_and_explicit_defaults_2() {
+        Jail::expect_with(|_| {
+            let config = ConfigWithInheritAndExplicitDefaultsTwo::from_env("TEST_").unwrap();
+
+            let ConfigWithInheritAndExplicitDefaultsTwo { a: Nested { b, c } } = config;
+            assert!(!b);
+            assert_eq!(c, 42);
+
+            Ok(())
+        });
+    }
+
+    #[derive(Deserialize, Config)]
+    #[config(core = "crate")]
     struct ConfigWithFlattenInheritDefaults {
         d: usize,
         #[serde(flatten)]


### PR DESCRIPTION
Fix a bug when both inherit and explicit default are set. Inherited fields was overwritten by explicit defaults.

# Example

## Source
```rust
    #[derive(Deserialize, Config)]
    struct Nested {
        #[config(default = "false")]
        b: bool,
        c: usize,
    }

    #[derive(Deserialize, Config)]
    struct Config {
        #[config(inherit, default = r#"{ "c": 42 }"#)]
        a: Nested,
    }
```

## Current Generated Code (Wrong)

Notice how the second insertion of key "a" overwrites the first one.

```rust
impl crate::utils::ConfigDefault for ConfigWithInheritAndExplicitDefaultsTwo {
    fn config_defaults() -> crate::utils::serde_json::Value {
        crate::utils::serde_json::Value::Object({
            {
                let mut dict = crate::utils::serde_json::Map::new();
                dict.insert("a".to_string(), <Nested as crate::utils::ConfigDefault>::config_defaults());
                dict.insert("a".to_string(), crate::utils::serde_json::from_str::<crate::utils::serde_json::Value>("{ \"c\": 42 }").expect("Given string literal is not a valid json value."));
                dict
            }
        })
    }
}
```

# Stacked PR

This PR is stacked on top of PR #145. It shouldn't be merged until #145 is merged.